### PR TITLE
Set TTL on dynamodb for available_ips

### DIFF
--- a/available_ips.py
+++ b/available_ips.py
@@ -2,6 +2,7 @@ import boto3
 import logging
 import os
 import sys
+import time
 sys.path.insert(0, './vendor')
 from sts import establish_role
 from boto3.dynamodb.conditions import Key, Attr
@@ -42,6 +43,8 @@ def available_ips(event, context):
                     subnet_id = subnet['SubnetId']
                     subnet = subnet['CidrBlock']
                     unique_id = f'{acct_id}{vpc_id}{subnet_id}{subnet}'
+                    # ttl set to 48 hours
+                    ttl_expire_time = int(time.time()) + 172800
 
                     response = available_ips_table.put_item(
                         Item={
@@ -51,7 +54,8 @@ def available_ips(event, context):
                             'SubnetId': subnet_id,
                             'Subnet': subnet,
                             'Region': region,
-                            'AvailableIpAddressCount': available_ips
+                            'AvailableIpAddressCount': available_ips,
+                            'ttl': ttl_expire_time
                         }
                     )
                     logger.info("Dynamodb response: {}".format(response))

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -240,6 +240,9 @@ resources:
           -
             AttributeName: id
             KeyType: HASH
+        TimeToLiveSpecification:
+          Enabled: true
+          AttributeName: 'ttl'
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 5


### PR DESCRIPTION
Instead of using prune_tables, let's go with item TTL for subnets and their available_ips entries. So, a subnet is removed we will no longer update it's TTL every 30 minutes leading to a 48 hour TTL expire event. This will keep things cleaned up.