### PR TITLE
Redesign for unlimited number of accounts and regions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,11 @@ Centralized AWS Lambda functions assume role on monitored AWS accounts to collec
 * [ALBs, NLBs (elbv2)](https://aws.amazon.com/documentation/elastic-load-balancing/)
 * Available IPv4 Addresses per subnet (Note that the IPv4 addresses for any stopped instances are considered unavailable)
 
+##### Collection subsystem runner process
+
+The above noted cidr-house-rules collection functions are triggered by a [runner function](https://github.com/trulia/cidr-house-rules/blob/master/runner.py) which invokes the necessary number of
+import functions based upon the number of AWS accounts managed and number of regions provided by AWS. The runner process allows for cidr-house-rules to scale given any number of AWS accounts to collect information from.
+
 #### API interface
 
 An API interface is provided to expose collected data for consumption. Example usage is through Terraform's [http data source](https://www.terraform.io/docs/providers/http/data_source.html)

--- a/available_ips.py
+++ b/available_ips.py
@@ -11,8 +11,11 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def available_ips(event, context):
-    """Record AvailableIpAddressCount for all subnets in all regions
     """
+    Take in event data which should contain AWS account and region and
+    record AvailableIpAddressCount for all subnets in all regions
+    """
+
     dynamodb = boto3.resource('dynamodb')
     client = boto3.client('ec2')
     available_ips_table = dynamodb.Table(

--- a/import_cidrs.py
+++ b/import_cidrs.py
@@ -13,68 +13,64 @@ def import_cidrs(event, context):
     dynamodb = boto3.resource('dynamodb')
     client = boto3.client('ec2')
     cidr_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_CIDRS'])
-    accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
-    accounts = accounts_table.scan()['Items']
     cidrs = cidr_table.scan()['Items']
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
+    account = event['account']
+    region  = event['region']
 
-    for region in regions:
-        for acct in accounts:
-            ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(acct)
-            client = boto3.client('ec2',
-                                  aws_access_key_id=ACCESS_KEY,
-                                  aws_secret_access_key=SECRET_KEY,
-                                  aws_session_token=SESSION_TOKEN,
-                                  region_name=region
-                                 )
-            vpcs = client.describe_vpcs()
+    ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(account)
+    client = boto3.client('ec2',
+                          aws_access_key_id=ACCESS_KEY,
+                          aws_secret_access_key=SECRET_KEY,
+                          aws_session_token=SESSION_TOKEN,
+                          region_name=region
+                         )
+    vpcs = client.describe_vpcs()
 
-            for vpc in vpcs['Vpcs']:
-                acct_id = acct['id']
-                vpc_cidr = vpc['CidrBlock']
-                vpc_id = vpc['VpcId']
-                unique_id = "{0}{1}{2}{3}".format(
-                    acct_id, vpc_cidr, region, vpc_id)
+    for vpc in vpcs['Vpcs']:
+        vpc_cidr = vpc['CidrBlock']
+        vpc_id = vpc['VpcId']
+        unique_id = "{0}{1}{2}{3}".format(
+            account, vpc_cidr, region, vpc_id)
 
-                logger.info(
-                "Found vpc-id: {0} and cidr: {1} ({2}) from "
-                "account {3} in Dyanmodb".format(
-                    vpc['VpcId'], vpc['CidrBlock'], region, acct['id']
+        logger.info(
+        "Found vpc-id: {0} and cidr: {1} ({2}) from "
+        "account {3} in Dyanmodb".format(
+            vpc['VpcId'], vpc['CidrBlock'], region, account
+            )
+        )
+
+        response = cidr_table.put_item(
+            Item={
+                'id': unique_id,
+                'cidr': vpc_cidr,
+                'AccountID': account,
+                'Region': region,
+                'VpcId': vpc_id,
+            },
+            ConditionExpression='attribute_not_exists(unique_id)'
+        )
+        logger.info("Dynamodb response: {}".format(response))
+
+        if 'CidrBlockAssociationSet' in vpc:
+            for cidr_associaton in vpc['CidrBlockAssociationSet']:
+                cidr_state = cidr_associaton['CidrBlockState']['State']
+                if cidr_state == "associated":
+                    unique_id = ("{0}{1}{2}{3}".format(
+                        account,
+                        cidr_associaton['CidrBlock'],
+                        region, vpc_id))
+                    response = cidr_table.put_item(
+                        Item={
+                            'id': unique_id,
+                            'cidr': cidr_associaton['CidrBlock'],
+                            'AccountID': account,
+                            'Region': region,
+                            'VpcId': vpc_id,
+                        },
+                        ConditionExpression=(
+                            'attribute_not_exists(unique_id)')
                     )
-                )
-
-                response = cidr_table.put_item(
-                    Item={
-                        'id': unique_id,
-                        'cidr': vpc_cidr,
-                        'AccountID': acct_id,
-                        'Region': region,
-                        'VpcId': vpc_id,
-                    },
-                    ConditionExpression='attribute_not_exists(unique_id)'
-                )
-                logger.info("Dynamodb response: {}".format(response))
-
-                if 'CidrBlockAssociationSet' in vpc:
-                    for cidr_associaton in vpc['CidrBlockAssociationSet']:
-                        cidr_state = cidr_associaton['CidrBlockState']['State']
-                        if cidr_state == "associated":
-                            unique_id = ("{0}{1}{2}{3}".format(
-                                acct_id,
-                                cidr_associaton['CidrBlock'],
-                                region, vpc_id))
-                            response = cidr_table.put_item(
-                                Item={
-                                    'id': unique_id,
-                                    'cidr': cidr_associaton['CidrBlock'],
-                                    'AccountID': acct_id,
-                                    'Region': region,
-                                    'VpcId': vpc_id,
-                                },
-                                ConditionExpression=(
-                                    'attribute_not_exists(unique_id)')
-                            )
-                            logger.info("Dynamodb response: {}".format(response))
-                        else:
-                            logger.info("CIDR: {} not associated".format(
-                                cidr_associaton['CidrBlock']))
+                    logger.info("Dynamodb response: {}".format(response))
+                else:
+                    logger.info("CIDR: {} not associated".format(
+                        cidr_associaton['CidrBlock']))

--- a/import_cidrs.py
+++ b/import_cidrs.py
@@ -10,6 +10,10 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def import_cidrs(event, context):
+    """
+    Take event data which should include AWS account and region and import
+    CIDR blocks that are in use
+    """
     dynamodb = boto3.resource('dynamodb')
     client = boto3.client('ec2')
     cidr_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_CIDRS'])

--- a/import_eips.py
+++ b/import_eips.py
@@ -12,53 +12,49 @@ def import_eips(event, context):
     dynamodb = boto3.resource('dynamodb')
     client = boto3.client('ec2')
     eip_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_EIP'])
-    accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
-    accounts = accounts_table.scan()['Items']
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
+    account = event['account']
+    region  = event['region']
 
-    for region in regions:
-        for acct in accounts:
-            ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(acct)
-            client = boto3.client('ec2',
-                                  aws_access_key_id=ACCESS_KEY,
-                                  aws_secret_access_key=SECRET_KEY,
-                                  aws_session_token=SESSION_TOKEN,
-                                  region_name=region
-                                 )
-            eips = client.describe_addresses()
-            if not eips['Addresses']:
-                logger.info("No allocated EIPs for acct: {0} in region {1}"
-                            .format(acct['id'], region))
+    ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(account)
+    client = boto3.client('ec2',
+                          aws_access_key_id=ACCESS_KEY,
+                          aws_secret_access_key=SECRET_KEY,
+                          aws_session_token=SESSION_TOKEN,
+                          region_name=region
+                         )
+    eips = client.describe_addresses()
+    if not eips['Addresses']:
+        logger.info("No allocated EIPs for account: {0} in region {1}"
+                    .format(account, region))
+    else:
+        for eip in eips['Addresses']:
+            eip_address = eip['PublicIp']
+            if 'AssociationId' in eip:
+                eip_association_id = eip['AssociationId']
             else:
-                for eip in eips['Addresses']:
-                    acct_id = acct['id']
-                    eip_address = eip['PublicIp']
-                    if 'AssociationId' in eip:
-                        eip_association_id = eip['AssociationId']
-                    else:
-                        logger.info(
-                            "No AllocadtionId found for EIP {0} in acct {1} {2}"
-                                    .format(eip_address, acct['id'], region))
-                        eip_association_id = "none"
-                    if 'AllocationId' in eip:
-                        eip_id = eip['AllocationId']
-                    else:
-                        logger.info(
-                            "No AllocadtionId found for EIP {0} in acct {1} {2}"
-                                    .format(eip_address, acct['id'], region))
-                        eip_id = "none"
+                logger.info(
+                    "No AllocadtionId found for EIP {0} in account {1} {2}"
+                            .format(eip_address, account, region))
+                eip_association_id = "none"
+            if 'AllocationId' in eip:
+                eip_id = eip['AllocationId']
+            else:
+                logger.info(
+                    "No AllocadtionId found for EIP {0} in account {1} {2}"
+                            .format(eip_address, account, region))
+                eip_id = "none"
 
-                    logger.info('Discovered EIP in use: {0} with ID: {1}'
-                                .format(eip_address, eip_id))
+            logger.info('Discovered EIP in use: {0} with ID: {1}'
+                        .format(eip_address, eip_id))
 
-                    response = eip_table.put_item(
-                        Item={
-                            'id': eip_address,
-                            'AllocationId': eip_id,
-                            'AccountID': acct_id,
-                            'AssociationId': eip_association_id,
-                            'Region': region
-                        },
-                        ConditionExpression='attribute_not_exists(eip_id)'
-                    )
-                    logger.info("Dynamodb response: {}".format(response))
+            response = eip_table.put_item(
+                Item={
+                    'id': eip_address,
+                    'AllocationId': eip_id,
+                    'AccountID': account, 
+                    'AssociationId': eip_association_id,
+                    'Region': region
+                },
+                ConditionExpression='attribute_not_exists(eip_id)'
+            )
+            logger.info("Dynamodb response: {}".format(response))

--- a/import_endpoint_services.py
+++ b/import_endpoint_services.py
@@ -17,55 +17,45 @@ def import_endpoint_services(event, context):
     client = boto3.client('ec2')
     endpoint_service_table = dynamodb.Table(
         os.environ['DYNAMODB_TABLE_ENDPOINT_SERVICES'])
-    accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
-    accounts = accounts_table.scan()['Items']
+    account = event['account']
+    region  = event['region']
     endpoint_services = endpoint_service_table.scan()['Items']
-    black_list_region = ['eu-west-3']
-    regions = [region['RegionName']
-               for region in client.describe_regions()['Regions']
-               if region['RegionName'] not in black_list_region]
-    logger.info('Here are the regions {}'.format(regions))
 
+    ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(account)
+    client = boto3.client('ec2',
+                          aws_access_key_id=ACCESS_KEY,
+                          aws_secret_access_key=SECRET_KEY,
+                          aws_session_token=SESSION_TOKEN,
+                          region_name=region
+                         )
+    logger.info(
+        'Looking up endpoint details on account {} in region {}'
+        .format(account, region))
+    endpoint_services = client.describe_vpc_endpoint_service_configurations()
 
-    for region in regions:
-        for acct in accounts:
-            ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(acct)
-            client = boto3.client('ec2',
-                                  aws_access_key_id=ACCESS_KEY,
-                                  aws_secret_access_key=SECRET_KEY,
-                                  aws_session_token=SESSION_TOKEN,
-                                  region_name=region
-                                 )
-            logger.info(
-                'Looking up endpoint details on account {} in region {}'
-                .format(acct['id'], region))
-            endpoint_services = client.describe_vpc_endpoint_service_configurations()
+    for endpoint_srv in endpoint_services['ServiceConfigurations']:
+        service_id = endpoint_srv['ServiceId']
+        service_name = endpoint_srv['ServiceName']
+        service_state= endpoint_srv['ServiceState']
+        acceptance_required = endpoint_srv['AcceptanceRequired']
+        nlb_arns = endpoint_srv['NetworkLoadBalancerArns']
+        # ttl set to 48 hours
+        ttl_expire_time = int(time.time()) + 172800
 
-            for endpoint_srv in endpoint_services['ServiceConfigurations']:
-                service_id = endpoint_srv['ServiceId']
-                service_name = endpoint_srv['ServiceName']
-                acct_id = acct['id']
-                service_state= endpoint_srv['ServiceState']
-                acceptance_required = endpoint_srv['AcceptanceRequired']
-                nlb_arns = endpoint_srv['NetworkLoadBalancerArns']
-                # ttl set to 48 hours
-                ttl_expire_time = int(time.time()) + 172800
+        logger.info(
+            'Recording Endpoint Service: {0} to nlbs {1} for account {2}'
+            .format(service_name, nlb_arns, account)
+        )
 
-
-                logger.info(
-                    'Recording Endpoint Service: {0} to nlbs {1} for account {2}'
-                    .format(service_name, nlb_arns, acct)
-                )
-
-                response = endpoint_service_table.put_item(
-                    Item={
-                        'id': service_id,
-                        'ServiceName': service_name,
-                        'AccountID': acct_id,
-                        'ServiceState': service_state,
-                        'AcceptanceRequired': acceptance_required,
-                        'NetworkLoadBalancerArns': nlb_arns,
-                        'Region': region,
-                        'ttl': ttl_expire_time
-                    }
-                )
+        response = endpoint_service_table.put_item(
+            Item={
+                'id': service_id,
+                'ServiceName': service_name,
+                'AccountID': account,
+                'ServiceState': service_state,
+                'AcceptanceRequired': acceptance_required,
+                'NetworkLoadBalancerArns': nlb_arns,
+                'Region': region,
+                'ttl': ttl_expire_time
+            }
+        )

--- a/import_nat_gateways.py
+++ b/import_nat_gateways.py
@@ -14,39 +14,35 @@ def import_nat_gateways(event, context):
     client = boto3.client('ec2')
     nat_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_NAT_GATEWAYS'])
     cidr_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_CIDRS'])
-    accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
-    accounts = accounts_table.scan()['Items']
     cidrs = cidr_table.scan()['Items']
-    regions = [region['RegionName'] for region in client.describe_regions()['Regions']]
+    account = event['account']
+    region  = event['region']
 
-    for region in regions:
-        for acct in accounts:
-            ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(acct)
-            client = boto3.client('ec2',
-                                  aws_access_key_id=ACCESS_KEY,
-                                  aws_secret_access_key=SECRET_KEY,
-                                  aws_session_token=SESSION_TOKEN,
-                                  region_name=region
-                                 )
-            nats = client.describe_nat_gateways()
+    ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(account)
+    client = boto3.client('ec2',
+                          aws_access_key_id=ACCESS_KEY,
+                          aws_secret_access_key=SECRET_KEY,
+                          aws_session_token=SESSION_TOKEN,
+                          region_name=region
+                         )
+    nats = client.describe_nat_gateways()
 
-            for nat in nats['NatGateways']:
-                public_ip = nat['NatGatewayAddresses'][0]['PublicIp']
-                acct_id = acct['id']
-                nat_id = nat['NatGatewayId']
-                nat_vpc_id = nat['VpcId']
+    for nat in nats['NatGateways']:
+        public_ip = nat['NatGatewayAddresses'][0]['PublicIp']
+        nat_id = nat['NatGatewayId']
+        nat_vpc_id = nat['VpcId']
 
-                logger.info('Logging NAT Gateway: {0} for account {1}'.format(
-                    public_ip, acct)
-                )
+        logger.info('Logging NAT Gateway: {0} for account {1}'.format(
+            public_ip, account)
+        )
 
-                response = nat_table.put_item(
-                    Item={
-                        'id': nat_id,
-                        'PublicIp': public_ip,
-                        'AccountID': acct_id,
-                        'VpcId': nat_vpc_id,
-                        'Region': region
-                    },
-                    ConditionExpression='attribute_not_exists(nat_id)'
-                )
+        response = nat_table.put_item(
+            Item={
+                'id': nat_id,
+                'PublicIp': public_ip,
+                'AccountID': account,
+                'VpcId': nat_vpc_id,
+                'Region': region
+            },
+            ConditionExpression='attribute_not_exists(nat_id)'
+        )

--- a/prune_tables.py
+++ b/prune_tables.py
@@ -10,6 +10,9 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 def prune_tables(event, context):
+    """Remove eips, cidrs, nats that are no longer used. DEPRECIATED, we should
+    now be using Dyanmodb TTLs to expire unused resources from database
+    """
     recorded_eips = {}
     recorded_cidrs = {}
     recorded_nats = {}

--- a/prune_tables.py
+++ b/prune_tables.py
@@ -52,7 +52,7 @@ def prune_tables(event, context):
 
     for region in regions:
         for acct in accounts:
-            ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(acct)
+            ACCESS_KEY, SECRET_KEY, SESSION_TOKEN = establish_role(acct['id'])
             client = boto3.client('ec2',
             aws_access_key_id=ACCESS_KEY,
             aws_secret_access_key=SECRET_KEY,

--- a/runner.py
+++ b/runner.py
@@ -22,6 +22,8 @@ regions = ([region['RegionName']
                 for region in client.describe_regions()['Regions']])
 
 def invoke_process(fuction_name, account_id, region):
+    """Launch target fuction_name on account_id and region
+    """
     invoke_payload = (
         json.JSONEncoder().encode(
             {
@@ -44,8 +46,8 @@ def runner(event, context):
     for region in regions:
         for acct in accounts:
             logger.info(
-"""
-Invoking cidr-house-rules-{0}-available_ips on account {1} in region {2}
-""".format(environment, acct['id'], region)
+                """
+                cidr-house-rules-{0}-available_ips on account {1} in region {2}
+                """.format(environment, acct['id'], region)
             )
             invoke_process(function_name, acct['id'], region)

--- a/runner.py
+++ b/runner.py
@@ -12,6 +12,8 @@ dynamodb = boto3.resource('dynamodb')
 client = boto3.client('ec2')
 lambda_client = boto3.client('lambda')
 function_name = os.environ['run']
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
 accounts = accounts_table.scan()['Items']

--- a/runner.py
+++ b/runner.py
@@ -1,4 +1,5 @@
 import boto3
+import json
 import logging
 import os
 import sys

--- a/runner.py
+++ b/runner.py
@@ -9,6 +9,7 @@ from boto3.dynamodb.conditions import Key, Attr
 
 environment = os.environ['ENV']
 dynamodb = boto3.resource('dynamodb')
+client = boto3.client('ec2')
 lambda_client = boto3.client('lambda')
 function_name = os.environ['run']
 

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,49 @@
+import boto3
+import logging
+import os
+import sys
+import time
+sys.path.insert(0, './vendor')
+from sts import establish_role
+from boto3.dynamodb.conditions import Key, Attr
+
+environment = os.environ['ENV']
+dynamodb = boto3.resource('dynamodb')
+lambda_client = boto3.client('lambda')
+
+accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
+accounts = accounts_table.scan()['Items']
+regions = ([region['RegionName']
+                for region in client.describe_regions()['Regions']])
+
+def invoke_process(fuction_name):
+    invoke_scanner_payload = (
+        json.JSONEncoder().encode(
+            {
+                "account": host['AccountID'],
+                "region": host['Region']
+            }
+        )
+    )
+    lambda_client.invoke(
+        FunctionName=fuction_name
+            'cidr-house-rules-port-scan-{}-invoke_scanner'.format(environment)
+        InvocationType='Event',
+        Payload=invoke_scanner_payload,
+    )
+
+def runner(event, context):
+    """Launch child import processes on a per account, per region basis
+    """
+
+    logger.info('Running available_ips...')
+    for region in regions:
+        for acct in accounts:
+            logger.info(
+"""
+Invoking cidr-house-rules-{0}-available_ips on account {1} in region {2}
+""".format(environment, acct['id'], region)
+            )
+            invoke_process(
+                'cidr-house-rules-{}-available_ips'.format(environment)
+            )

--- a/runner.py
+++ b/runner.py
@@ -10,26 +10,26 @@ from boto3.dynamodb.conditions import Key, Attr
 environment = os.environ['ENV']
 dynamodb = boto3.resource('dynamodb')
 lambda_client = boto3.client('lambda')
+function_name = os.environ['run']
 
 accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
 accounts = accounts_table.scan()['Items']
 regions = ([region['RegionName']
                 for region in client.describe_regions()['Regions']])
 
-def invoke_process(fuction_name):
-    invoke_scanner_payload = (
+def invoke_process(fuction_name, account_id, region):
+    invoke_payload = (
         json.JSONEncoder().encode(
             {
-                "account": host['AccountID'],
-                "region": host['Region']
+                "account": account_id,
+                "region": region
             }
         )
     )
     lambda_client.invoke(
         FunctionName=fuction_name
-            'cidr-house-rules-port-scan-{}-invoke_scanner'.format(environment)
         InvocationType='Event',
-        Payload=invoke_scanner_payload,
+        Payload=invoke_payload,
     )
 
 def runner(event, context):
@@ -44,6 +44,4 @@ def runner(event, context):
 Invoking cidr-house-rules-{0}-available_ips on account {1} in region {2}
 """.format(environment, acct['id'], region)
             )
-            invoke_process(
-                'cidr-house-rules-{}-available_ips'.format(environment)
-            )
+            invoke_process(function_name, acct['id'], region)

--- a/runner.py
+++ b/runner.py
@@ -27,7 +27,7 @@ def invoke_process(fuction_name, account_id, region):
         )
     )
     lambda_client.invoke(
-        FunctionName=fuction_name
+        FunctionName=fuction_name,
         InvocationType='Event',
         Payload=invoke_payload,
     )

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -69,18 +69,55 @@ provider:
         - "*"
 
 functions:
-  runner-availabe_ips:
+  runner-available_ips:
     handler: runner.runner
     environment:
       run: cidr-house-rules-${opt:stage, self:provider.stage}-available_ips
     events:
-      - schedule: cron(0,30 * * * *)
+      - schedule:
+          rate: cron(0,30 * * * ? *)
   runner-import_cidrs:
     handler: runner.runner
     environment:
       run: cidr-house-rules-${opt:stage, self:provider.stage}-import_cidrs
     events:
-      - schedule: cron(5,35 * * * *)
+      - schedule:
+          rate: cron(5,35 * * * ? *)
+  runner-import_nat_gateways:
+    handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-import_nat_gateways
+    events:
+      - schedule:
+          rate: cron(8,38 * * * ? *)
+  runner-import_eips:
+    handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-import_eips
+    events:
+      - schedule:
+          rate: cron(10,40 * * * ? *)
+  runner-import_elbs_classic:
+    handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-import_elbs_classic
+    events:
+      - schedule:
+          rate: cron(12,42 * * * ? *)
+  runner-import_elbsv2:
+    handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-import_elbsv2
+    events:
+      - schedule:
+          rate: cron(14,44 * * * ? *)
+  runner-import_endpoint_services:
+    handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-import_endpoint_services
+    events:
+      - schedule:
+          rate: cron(16,47 * * * ? *)
   import_cidrs:
     handler: import_cidrs.import_cidrs
     memorySize: 128
@@ -89,18 +126,13 @@ functions:
     memorySize: 128
   import_nat_gateways:
     handler: import_nat_gateways.import_nat_gateways
-    events:
-     - schedule: rate(1 hour)
+    memorySize: 128
   import_eips:
     handler: import_eips.import_eips
     memorySize: 128
-    events:
-     - schedule: rate(1 hour)
   import_elbs_classic:
     handler: import_elbs_classic.import_elbs
     memorySize: 128
-    events:
-     - schedule: rate(1 hour)
   import_elbsv2:
     handler: import_elbsv2.import_elbs
     memorySize: 128
@@ -109,8 +141,6 @@ functions:
   import_endpoint_services:
     handler: import_endpoint_services.import_endpoint_services
     memorySize: 128
-    events:
-     - schedule: rate(30 minutes)
   prune_tables:
     handler: prune_tables.prune_tables
     memorySize: 128
@@ -248,7 +278,7 @@ resources:
             AttributeName: id
             KeyType: HASH
         ProvisionedThroughput:
-          ReadCapacityUnits: 1
+          ReadCapacityUnits: 3
           WriteCapacityUnits: 5
         TableName: '${self:provider.environment.DYNAMODB_TABLE_NAT_GATEWAYS}'
     EIPDynamoDbTable:
@@ -264,7 +294,7 @@ resources:
             AttributeName: id
             KeyType: HASH
         ProvisionedThroughput:
-          ReadCapacityUnits: 1
+          ReadCapacityUnits: 3
           WriteCapacityUnits: 5
         TableName: '${self:provider.environment.DYNAMODB_TABLE_EIP}'
     ELBDynamoDbTable:
@@ -280,7 +310,7 @@ resources:
             AttributeName: id
             KeyType: HASH
         ProvisionedThroughput:
-          ReadCapacityUnits: 1
+          ReadCapacityUnits: 3
           WriteCapacityUnits: 5
         TableName: '${self:provider.environment.DYNAMODB_TABLE_ELB}'
     AvailableIPsDynamoDbTable:
@@ -299,7 +329,7 @@ resources:
           Enabled: true
           AttributeName: 'ttl'
         ProvisionedThroughput:
-          ReadCapacityUnits: 1
+          ReadCapacityUnits: 3
           WriteCapacityUnits: 5
         TableName: '${self:provider.environment.DYNAMODB_TABLE_AVAILABLE_IPS}'
     EndpointServicesDynamoDbTable:

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -38,6 +38,10 @@ provider:
     ENV: ${opt:stage, self:provider.stage}
   iamRoleStatements:
     - Effect: Allow
+        Action:
+          - lambda:InvokeFunction
+        Resource: "*"
+    - Effect: Allow
       Action: sts:AssumeRole
       Resource:
         - "arn:aws:iam::<add_remote_account_number_here>:role/role_cidr_house"
@@ -66,14 +70,24 @@ provider:
         - "*"
 
 functions:
-  runner:
+  runner-availabe_ips:
     handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-available_ips
     events:
-      - schedule: rate(30 minutes)
+      - schedule: cron(0,30 * * * *)
+  runner-import_cidrs:
+    handler: runner.runner
+    environment:
+      run: cidr-house-rules-${opt:stage, self:provider.stage}-import_cidrs
+    events:
+      - schedule: cron(5,35 * * * *)
   import_cidrs:
     handler: import_cidrs.import_cidrs
-    events:
-     - schedule: rate(1 hour)
+    memorySize: 128
+  available_ips:
+    handler: available_ips.available_ips
+    memorySize: 128
   import_nat_gateways:
     handler: import_nat_gateways.import_nat_gateways
     events:
@@ -93,9 +107,6 @@ functions:
     memorySize: 128
     events:
      - schedule: rate(1 hour)
-  available_ips:
-    handler: available_ips.available_ips
-    memorySize: 128
   import_endpoint_services:
     handler: import_endpoint_services.import_endpoint_services
     memorySize: 128

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -38,9 +38,8 @@ provider:
     ENV: ${opt:stage, self:provider.stage}
   iamRoleStatements:
     - Effect: Allow
-        Action:
-          - lambda:InvokeFunction
-        Resource: "*"
+      Action: lambda:InvokeFunction
+      Resource: "*"
     - Effect: Allow
       Action: sts:AssumeRole
       Resource:

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -66,6 +66,10 @@ provider:
         - "*"
 
 functions:
+  runner:
+    handler: runner.runner
+    events:
+      - schedule: rate(30 minutes)
   import_cidrs:
     handler: import_cidrs.import_cidrs
     events:
@@ -92,8 +96,6 @@ functions:
   available_ips:
     handler: available_ips.available_ips
     memorySize: 128
-    events:
-     - schedule: rate(30 minutes)
   import_endpoint_services:
     handler: import_endpoint_services.import_endpoint_services
     memorySize: 128

--- a/sts.py
+++ b/sts.py
@@ -12,7 +12,7 @@ class DateTimeEncoder(json.JSONEncoder):
 def establish_role(acct):
     sts_connection = boto3.client('sts')
     acct_b = sts_connection.assume_role(
-        RoleArn="arn:aws:iam::{}:role/role_cidr_house".format(acct['id']),
+        RoleArn="arn:aws:iam::{}:role/role_cidr_house".format(acct),
         RoleSessionName="cross_acct_lambda"
     )
     d = json.dumps(acct_b, cls=DateTimeEncoder)


### PR DESCRIPTION
* New runner function code runner used to invoke children import functions
* Update available_ips to be invoked by runner
* Update import_cidrs to be invoked by runner
* Update Import_eips to be invoked by runner
* Update import_elbs_classic to be invoked by runner
* Update import_elbsv2 to be invoked by runner
* Update import_endpoint_services to be invoked by runner
* Update import_nat_gateways to be invoked by runner
* Add depreciation documentation to prune process, in favor of using TTLs
* Update sts to use account ID as input
* Update serverless.example.yml with new runner layout
