### PR TITLE
Adding paginated results for nat gateway

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -116,6 +116,24 @@ curl \
    https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_nat_gateways_for_all
 ```
 
+##### Obtain number of result pages for NAT gatways, useful for Terraform to count out resources on
+
+```bash
+# Default is 50 results per page
+curl --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" 'https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_number_of_nat_gateway_pages'
+```
+
+```bash
+# Request number of results per page to be 10, and return total number of pages
+curl --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" 'https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_number_of_nat_gateway_pages?results_per_page=10'
+```
+
+##### Obtain paged results of Nat gateways results
+
+```bash
+curl --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" 'https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_nat_gateways_for_all?results_per_page=10&page=4'
+```
+
 ##### Check for a VPC CIDR conflict
 
 ```bash
@@ -137,7 +155,7 @@ https://yourapigateway-endpoint-generated-by-serverless.com/dev/get_elbs_for_all
 ```bash
 curl \
   --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" \
-  https://yourapigateway-endpoint-generated-by-serverless.com/dev/add_account?team=my_aws_account_alias_here?account=35682931234
+  https://yourapigateway-endpoint-generated-by-serverless.com/dev/add_account?team=my_aws_account_alias_here&account=35682931234
 ```
 
 #####  Supporting Terraform

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -81,7 +81,7 @@ def get_number_of_nat_gateway_pages(event, context):
         pages = math.ceil(len(response) / results_per_page)
         logger.info(f'pages: {pages}')
 
-        return pages
+        return _return_200(pages)
 
     except ValueError:
         _return_422('Invalid input')

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -210,8 +210,9 @@ def _ip_list_formatter(ip_list):
 
 def _ip_list_pagination(ip_list, results_per_page):
     """Return paginated results for list of ips."""
-    [ip_list[i:i+results_per_page]
+    paged_response = [ip_list[i:i+results_per_page]
      for i in range(0, len(ip_list), results_per_page)]
+    return paged_response
 
 def _not_items_found(service, account_id):
     """Return 422 response code when items not found in DynamoDB"""

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -111,7 +111,8 @@ def get_nat_gateways_for_all(event, context):
         if event['queryStringParameters']:
             if event['queryStringParameters']['page']:
                 page = event['queryStringParameters']['page']
-                paged_response = _ip_list_pagination(response, results_per_page)
+                paged_response = _ip_list_pagination(
+                    response, int(results_per_page))
                 formatted_response = _ip_list_formatter(paged_response)
         else:
             formatted_response = _ip_list_formatter(response)
@@ -207,7 +208,7 @@ def _ip_list_formatter(ip_list):
 def _ip_list_pagination(ip_list, results_per_page):
     """Return paginated results for list of ips."""
     [ip_list[i:i+results_per_page]
-     for i in range(0, len(ip_list), int(results_per_page))]
+     for i in range(0, len(ip_list), results_per_page)]
 
 def _not_items_found(service, account_id):
     """Return 422 response code when items not found in DynamoDB"""

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -100,17 +100,19 @@ def get_nat_gateways_for_all(event, context):
         for n in nat_gateways['Items']:
             response.append(n['PublicIp'] + '/32')
 
-        if event['queryStringParameters']['results_per_page'] in event:
-            results_per_page = (
-                event['queryStringParameters']['results_per_page'])
+        if event['queryStringParameters']:
+            if event['queryStringParameters']['results_per_page']:
+                results_per_page = (
+                    event['queryStringParameters']['results_per_page'])
         else:
             # Default to 50 results per page if parameter not given
             results_per_page = 50
 
-        if event['queryStringParameters']['page'] in event:
-            page = event['queryStringParameters']['page']
-            paged_response = _ip_list_pagination(response, results_per_page)
-            formatted_response = _ip_list_formatter(paged_response)
+        if event['queryStringParameters']:
+            if event['queryStringParameters']['page']:
+                page = event['queryStringParameters']['page']
+                paged_response = _ip_list_pagination(response, results_per_page)
+                formatted_response = _ip_list_formatter(paged_response)
         else:
             formatted_response = _ip_list_formatter(response)
 

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -77,7 +77,9 @@ def get_number_of_nat_gateway_pages(event, context):
         else:
             results_per_page = 50
 
+        logger.info(f'response: {response}')
         pages = math.ceil(len(response) / results_per_page)
+        logger.info(f'pages: {pages}')
 
         return pages
 

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -70,9 +70,12 @@ def get_number_of_nat_gateway_pages(event, context):
         for n in nat_gateways['Items']:
             response.append(n['PublicIp'] + '/32')
 
-        if event['queryStringParameters']['results_per_page'] in event:
-            results_per_page = (
-                event['queryStringParameters']['results_per_page'])
+        if event['queryStringParameters']:
+            if event['queryStringParameters']['results_per_page']:
+                results_per_page = (
+                    event['queryStringParameters']['results_per_page'])
+        else:
+            results_per_page = 50
 
         pages = math.ceil(len(response) / results_per_page)
 

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -70,12 +70,7 @@ def get_number_of_nat_gateway_pages(event, context):
         for n in nat_gateways['Items']:
             response.append(n['PublicIp'] + '/32')
 
-        if event['queryStringParameters']:
-            if event['queryStringParameters']['results_per_page']:
-                results_per_page = (
-                    int(event['queryStringParameters']['results_per_page']))
-        else:
-            results_per_page = 50
+        results_per_page = _check_results_per_page(event)
 
         logger.info(f'response: {response}')
         pages = math.ceil(len(response) / results_per_page)
@@ -102,13 +97,7 @@ def get_nat_gateways_for_all(event, context):
         for n in nat_gateways['Items']:
             response.append(n['PublicIp'] + '/32')
 
-        if event['queryStringParameters']:
-            if event['queryStringParameters']['results_per_page']:
-                results_per_page = (
-                    int(event['queryStringParameters']['results_per_page']))
-        else:
-            # Default to 50 results per page if parameter not given
-            results_per_page = 50
+        results_per_page = _check_results_per_page(event)
 
         if event['queryStringParameters']:
             if event['queryStringParameters']['page']:
@@ -224,6 +213,17 @@ def _not_items_found(service, account_id):
         "statusCode": 422,
         "body": f'No {service} found for account: {account_id}'
     }
+
+def _check_results_per_page(event):
+    if event['queryStringParameters']:
+        if event['queryStringParameters']['results_per_page']:
+            results_per_page = (
+                int(event['queryStringParameters']['results_per_page']))
+    else:
+        # Default to 50 results per page if parameter not given
+        results_per_page = 50
+
+    return results_per_page
 
 def _return_200(response_body):
     """Return 200 response with provided body message"""

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -73,7 +73,7 @@ def get_number_of_nat_gateway_pages(event, context):
         if event['queryStringParameters']:
             if event['queryStringParameters']['results_per_page']:
                 results_per_page = (
-                    event['queryStringParameters']['results_per_page'])
+                    int(event['queryStringParameters']['results_per_page']))
         else:
             results_per_page = 50
 
@@ -103,17 +103,17 @@ def get_nat_gateways_for_all(event, context):
         if event['queryStringParameters']:
             if event['queryStringParameters']['results_per_page']:
                 results_per_page = (
-                    event['queryStringParameters']['results_per_page'])
+                    int(event['queryStringParameters']['results_per_page']))
         else:
             # Default to 50 results per page if parameter not given
             results_per_page = 50
 
         if event['queryStringParameters']:
             if event['queryStringParameters']['page']:
-                page = event['queryStringParameters']['page']
+                page = int(event['queryStringParameters']['page'])
                 logger.info(f'response: {response}')
                 paged_response = _ip_list_pagination(
-                    response, int(results_per_page))
+                    response, results_per_page)
                 logger.info(f'paged_response: {paged_response}')
                 # formatted_response should be the page requested
                 formatted_response = _ip_list_formatter(paged_response[0 + page])

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -76,6 +76,9 @@ def get_number_of_nat_gateway_pages(event, context):
 
         return pages
 
+    except ValueError:
+        _return_422('Invalid input')
+
 def get_nat_gateways_for_all(event, context):
     """Return NAT Gateways for all teams. Optional, pagination with ?page and
     ?results_per_page URI query parameters"""

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -207,7 +207,7 @@ def _ip_list_formatter(ip_list):
 def _ip_list_pagination(ip_list, results_per_page):
     """Return paginated results for list of ips."""
     [ip_list[i:i+results_per_page]
-     for i in range(0, len(ip_list), results_per_page)]
+     for i in range(0, len(ip_list), int(results_per_page))]
 
 def _not_items_found(service, account_id):
     """Return 422 response code when items not found in DynamoDB"""

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -115,7 +115,8 @@ def get_nat_gateways_for_all(event, context):
                 paged_response = _ip_list_pagination(
                     response, int(results_per_page))
                 logger.info(f'paged_response: {paged_response}')
-                formatted_response = _ip_list_formatter(paged_response)
+                # formatted_response should be the page requested
+                formatted_response = _ip_list_formatter(paged_response[0 + page])
                 logger.info(f'formatted_response: {formatted_response}')
         else:
             formatted_response = _ip_list_formatter(response)

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -58,6 +58,8 @@ def get_number_of_nat_gateway_pages(event, context):
     """Get the number of pages of NAT gateways with given number of results per
     page with ?results_per_page parameter"""
 
+    logger.info(f'DEBUG: {event}')
+
     dynamodb = boto3.resource('dynamodb')
     nat_gateways_table = dynamodb.Table(
         os.environ['DYNAMODB_TABLE_NAT_GATEWAYS'])
@@ -68,7 +70,7 @@ def get_number_of_nat_gateway_pages(event, context):
         for n in nat_gateways['Items']:
             response.append(n['PublicIp'] + '/32')
 
-        if event['queryStringParameters']['results_per_page']:
+        if event['queryStringParameters']['results_per_page'] in event:
             results_per_page = (
                 event['queryStringParameters']['results_per_page'])
 
@@ -83,6 +85,8 @@ def get_nat_gateways_for_all(event, context):
     """Return NAT Gateways for all teams. Optional, pagination with ?page and
     ?results_per_page URI query parameters"""
 
+    logger.info(f'DEBUG: {event}')
+
     dynamodb = boto3.resource('dynamodb')
     nat_gateways_table = dynamodb.Table(
         os.environ['DYNAMODB_TABLE_NAT_GATEWAYS'])
@@ -93,14 +97,14 @@ def get_nat_gateways_for_all(event, context):
         for n in nat_gateways['Items']:
             response.append(n['PublicIp'] + '/32')
 
-        if event['queryStringParameters']['results_per_page']:
+        if event['queryStringParameters']['results_per_page'] in event:
             results_per_page = (
                 event['queryStringParameters']['results_per_page'])
         else:
             # Default to 50 results per page if parameter not given
             results_per_page = 50
 
-        if event['queryStringParameters']['page']:
+        if event['queryStringParameters']['page'] in event:
             page = event['queryStringParameters']['page']
             paged_response = _ip_list_pagination(response, results_per_page)
             formatted_response = _ip_list_formatter(paged_response)

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -111,9 +111,12 @@ def get_nat_gateways_for_all(event, context):
         if event['queryStringParameters']:
             if event['queryStringParameters']['page']:
                 page = event['queryStringParameters']['page']
+                logger.info(f'response: {response}')
                 paged_response = _ip_list_pagination(
                     response, int(results_per_page))
+                logger.info(f'paged_response: {paged_response}')
                 formatted_response = _ip_list_formatter(paged_response)
+                logger.info(f'formatted_response: {formatted_response}')
         else:
             formatted_response = _ip_list_formatter(response)
 

--- a/serverless.example.yml
+++ b/serverless.example.yml
@@ -241,6 +241,40 @@ functions:
           path: get_nat_gateways_for_all
           method: get
           private: true
+          documentation:
+            summary: "Return NAT Gateways for all teams"
+            requestBody:
+              description: "Empty body"
+            requestHeaders:
+              -
+                name: "X-Api-Key"
+                description: "Requires an active API key for accessing this function"
+            queryParams:
+              -
+                name: "results_per_page"
+                description: "provide the AWS account number, optional, used if page queyer is specified"
+              -
+                name: "page"
+                description: "provide the AWS account number, optional, default will return all results in one page"
+  get_number_of_nat_gateway_pages:
+    handler: api_handlers.get_number_of_nat_gateway_pages
+    events:
+      - http:
+          path: get_number_of_nat_gateway_pages
+          method: get
+          private: true
+          documentation:
+            summary: "Get the number of pages of NAT gateways with given number of results"
+            requestBody:
+              description: "Empty body"
+            requestHeaders:
+              -
+                name: "X-Api-Key"
+                description: "Requires an active API key for accessing this function"
+            queryParams:
+              -
+                name: "results_per_page"
+                description: "provide the AWS account number"
   get_nat_gateways_for_team:
     handler: api_handlers.get_nat_gateways_for_team
     events:

--- a/tests/nat_gateways_test.py
+++ b/tests/nat_gateways_test.py
@@ -69,8 +69,10 @@ class TestNatGateways(unittest.TestCase):
 
         for i in range(0, 5):
             self.client.create_vpc(
-                CidrBlock='10.0.100.0/24'
+                CidrBlock=f'10.{i}.100.0/24'
             )
+
+        for i in range(0, 70):
             self.client.allocate_address(
                 Domain='vpc'
             )
@@ -86,10 +88,10 @@ class TestNatGateways(unittest.TestCase):
 
         subnet_ids = self.client.describe_subnets()
 
-        for i in range(0, 5):
+        for i in eips['Addresses']:
             self.client.create_nat_gateway(
-                AllocationId=eips['Addresses'][i]['AllocationId'],
-                SubnetId=subnet_ids['Subnets'][i]['SubnetId']
+                AllocationId=[i][0]['AllocationId'],
+                SubnetId=subnet_ids['Subnets'][0]['SubnetId']
             )
 
         invoke_payload = (
@@ -107,21 +109,137 @@ class TestNatGateways(unittest.TestCase):
         nats_table_items = self.nats_table.scan()['Items']
         nats = self.client.describe_nat_gateways()
 
-        # Todo
         # Mock API Gateway event
-        #number_of_pages = api_handlers.get_number_of_nat_gateway_pages()
+        api_response_get_number_of_nat_gateway_pages_default = (
+            {'body': None,
+             'headers': {'Accept': '*/*',
+                         'CloudFront-Forwarded-Proto': 'https',
+                         'CloudFront-Is-Desktop-Viewer': 'true',
+                         'CloudFront-Is-Mobile-Viewer': 'false',
+                         'CloudFront-Is-SmartTV-Viewer': 'false',
+                         'CloudFront-Is-Tablet-Viewer': 'false',
+                         'CloudFront-Viewer-Country': 'US',
+                         'Host': 'foobar.execute-api.us-west-2.amazonaws.com',
+                         'User-Agent': 'curl/7.54.0',
+                         'Via': '2.0 6895.cloudfront.net (CloudFront)',
+                         'X-Amz-Cf-Id': 'foobar===',
+                         'X-Amzn-Trace-Id': 'Root=1-5afb0foobar',
+                         'X-Forwarded-For': '127.0.0.1',
+                         'X-Forwarded-Port': '443',
+                         'X-Forwarded-Proto': 'https',
+                         'x-api-key': 'foobarapikey'
+                         },
+             'httpMethod': 'GET',
+             'isBase64Encoded': False,
+             'path': '/get_number_of_nat_gateway_pages',
+             'pathParameters': None,
+             'queryStringParameters': None,
+             'requestContext': {'accountId': '123456789',
+                                'apiId': 'foobarapi',
+                                'extendedRequestId': 'foobarreqid',
+                                'httpMethod': 'GET',
+                                'identity': {'accessKey': None,
+                                             'accountId': None,
+                                             'apiKey': 'foobarapikey',
+                                             'apiKeyId': 'foobarkeyid',
+                                             'caller': None,
+                                             'cognitoAuthenticationProvider': None,
+                                             'cognitoAuthenticationType': None,
+                                             'cognitoIdentityId': None,
+                                             'cognitoIdentityPoolId': None,
+                                             'sourceIp': '127.0.0.1',
+                                             'user': None,
+                                             'userAgent': 'curl/7.54.0',
+                                             'userArn': None},
+                                'path': '/dev/get_number_of_nat_gateway_pages',
+                                'protocol': 'HTTP/1.1',
+                                'requestId': 'foobarrequestid',
+                                'requestTime': '15/May/2018:16:31:14 +0000',
+                                'requestTimeEpoch': 1526401874029,
+                                'resourceId': 'foobarid',
+                                'resourcePath': '/get_number_of_nat_gateway_pages',
+                                'stage': 'dev'},
+             'resource': '/get_number_of_nat_gateway_pages',
+             'stageVariables': None}
+            )
+
+        api_response_get_number_of_nat_gateway_pages_10_per_page = (
+            {'body': None,
+             'headers': {'Accept': '*/*',
+                         'CloudFront-Forwarded-Proto': 'https',
+                         'CloudFront-Is-Desktop-Viewer': 'true',
+                         'CloudFront-Is-Mobile-Viewer': 'false',
+                         'CloudFront-Is-SmartTV-Viewer': 'false',
+                         'CloudFront-Is-Tablet-Viewer': 'false',
+                         'CloudFront-Viewer-Country': 'US',
+                         'Host': 'foobar.execute-api.us-west-2.amazonaws.com',
+                         'User-Agent': 'curl/7.54.0',
+                         'Via': '2.0 6895.cloudfront.net (CloudFront)',
+                         'X-Amz-Cf-Id': 'foobar===',
+                         'X-Amzn-Trace-Id': 'Root=1-5afb0foobar',
+                         'X-Forwarded-For': '127.0.0.1',
+                         'X-Forwarded-Port': '443',
+                         'X-Forwarded-Proto': 'https',
+                         'x-api-key': 'foobarapikey'
+                         },
+             'httpMethod': 'GET',
+             'isBase64Encoded': False,
+             'path': '/get_number_of_nat_gateway_pages',
+             'pathParameters': None,
+             'queryStringParameters': {'results_per_page': '10'},
+             'requestContext': {'accountId': '123456789',
+                                'apiId': 'foobarapi',
+                                'extendedRequestId': 'foobarreqid',
+                                'httpMethod': 'GET',
+                                'identity': {'accessKey': None,
+                                             'accountId': None,
+                                             'apiKey': 'foobarapikey',
+                                             'apiKeyId': 'foobarkeyid',
+                                             'caller': None,
+                                             'cognitoAuthenticationProvider': None,
+                                             'cognitoAuthenticationType': None,
+                                             'cognitoIdentityId': None,
+                                             'cognitoIdentityPoolId': None,
+                                             'sourceIp': '127.0.0.1',
+                                             'user': None,
+                                             'userAgent': 'curl/7.54.0',
+                                             'userArn': None},
+                                'path': '/dev/get_number_of_nat_gateway_pages',
+                                'protocol': 'HTTP/1.1',
+                                'requestId': 'foobarrequestid',
+                                'requestTime': '15/May/2018:16:31:14 +0000',
+                                'requestTimeEpoch': 1526401874029,
+                                'resourceId': 'foobarid',
+                                'resourcePath': '/get_number_of_nat_gateway_pages',
+                                'stage': 'dev'},
+             'resource': '/get_number_of_nat_gateway_pages',
+             'stageVariables': None}
+            )
+
+        number_of_pages = api_handlers.get_number_of_nat_gateway_pages(
+            api_response_get_number_of_nat_gateway_pages_default, None
+        )
+
+        number_of_pages_with_10_as_result = (
+            api_handlers.get_number_of_nat_gateway_pages(
+                api_response_get_number_of_nat_gateway_pages_10_per_page, None)
+            )
 
         # Validate that 5 EIPs were imported
-        self.assertEqual(len(nats_table_items), 5)
+        self.assertEqual(len(nats_table_items), 70)
 
         # Validate NAT Gateways found in Dynamodb table, do they match with mock
         for nat in nats_table_items:
             self.assertIn(nat['id'], [nat_id['NatGatewayId']
                                       for nat_id in nats['NatGateways']])
 
-        # Todo
-        # Validate api_handler response for get_number_of_nat_gateway_pages
-        #self.assertEqual(len())
+        # Validate api_handler response for get_number_of_nat_gateway_pages with
+        # default of 50 results per page
+        self.assertEqual(number_of_pages['body'], 2)
+
+        # Validate api_handler response for get_number_of_nat_gateway_pages with
+        # with requested 10 results per page
+        self.assertEqual(number_of_pages_with_10_as_result['body'], 7)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/nat_gateways_test.py
+++ b/tests/nat_gateways_test.py
@@ -6,14 +6,15 @@ import json
 sys.path.insert(0, './')
 import sts
 import import_nat_gateways
+import api_handlers
 from moto import mock_dynamodb2, mock_sts, mock_ec2
 
-class TestImportNatGateways(unittest.TestCase):
+class TestNatGateways(unittest.TestCase):
 
     @mock_ec2
     @mock_dynamodb2
     @mock_sts
-    def test_import_nat_gateways(self):
+    def test_nat_gateways(self):
         """Setup DynamoDB tables for NatDynamoDbTable.
         Provision some NAT Gatways
         """
@@ -106,6 +107,10 @@ class TestImportNatGateways(unittest.TestCase):
         nats_table_items = self.nats_table.scan()['Items']
         nats = self.client.describe_nat_gateways()
 
+        # Todo
+        # Mock API Gateway event
+        #number_of_pages = api_handlers.get_number_of_nat_gateway_pages()
+
         # Validate that 5 EIPs were imported
         self.assertEqual(len(nats_table_items), 5)
 
@@ -113,6 +118,10 @@ class TestImportNatGateways(unittest.TestCase):
         for nat in nats_table_items:
             self.assertIn(nat['id'], [nat_id['NatGatewayId']
                                       for nat_id in nats['NatGateways']])
+
+        # Todo
+        # Validate api_handler response for get_number_of_nat_gateway_pages
+        #self.assertEqual(len())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adding paginated results for nat gateway as an optional return. Default to return all in one page (current behavior)

Adding an endpoint to discover the number of pages for a response given the number of results_per_page. Needed for Terraform to generate appropriate HTTP data objects

Covers what is needed in https://github.com/trulia/cidr-house-rules/issues/29
