### PR TITLE
Changed nat gateway team request to accept multiple teams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__
 node_modules
 serverless.yml
 
+.idea

--- a/Readme.md
+++ b/Readme.md
@@ -106,6 +106,11 @@ iamRoleStatements:
 curl \
   --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" \
    https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_nat_gateways_for_team?platform&webteam&dataeng
+
+# Or just one team
+curl \
+  --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" \
+  https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_nat_gateways_for_team?team=platform
 ```
 
 ##### Obtain NAT gateways for all monitored accounts

--- a/Readme.md
+++ b/Readme.md
@@ -100,12 +100,12 @@ iamRoleStatements:
 
 #### Example API calls
 
-##### Obtain NAT gateways for platform team
+##### Obtain NAT gateways for platform, webteam and dataeng teams
 
 ```bash
 curl \
   --header "X-Api-Key: <GET_KEY_FROM_AWS_API_GATEWAY>" \
-   https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_nat_gateways_for_team?team=platform
+   https://yourapigateway-endpoint-generated-by-serverless.com/prod/get_nat_gateways_for_team?platform&webteam&dataeng
 ```
 
 ##### Obtain NAT gateways for all monitored accounts

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -124,7 +124,7 @@ def get_nat_gateways_for_team(event, context):
     dynamodb = boto3.resource('dynamodb')
     accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
     nat_gateways_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_NAT_GATEWAYS'])
-    if event['queryStringParameters']['team']:
+    if 'team' in event['queryStringParameters']:
         input_teams = [event['queryStringParameters']['team']]
     else:
         input_teams = event['queryStringParameters']

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -134,7 +134,6 @@ def get_nat_gateways_for_team(event, context):
 
     try:
         for team in input_teams:
-            print(f'here is team: {team}')
             accounts = accounts_table.scan()
             for a in accounts['Items']:
                 if a['team'] == team:

--- a/api_handlers.py
+++ b/api_handlers.py
@@ -124,7 +124,10 @@ def get_nat_gateways_for_team(event, context):
     dynamodb = boto3.resource('dynamodb')
     accounts_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_ACCOUNTS'])
     nat_gateways_table = dynamodb.Table(os.environ['DYNAMODB_TABLE_NAT_GATEWAYS'])
-    input_teams = event['queryStringParameters']
+    if event['queryStringParameters']['team']:
+        input_teams = [event['queryStringParameters']['team']]
+    else:
+        input_teams = event['queryStringParameters']
     response = []
     logger.info(f'Event: {event}')
 


### PR DESCRIPTION
Provides a response for multiple teams based on query params provided

* Support both single team request /get_nat_gateways_for_team?team=footeam
   and multiple teams /get_nat_gateways_for_team?footeam&barteam&corpteam
* just expects team names as parameter keys if multiple teams
* renamed _not_items_found() to _no_items_found()
* return is the same as before (it can not contain the NAT gateways of 1 or more teams)
